### PR TITLE
Saving/checking/loading a temporary file in census_geo_api

### DIFF
--- a/R/census_geo_api.R
+++ b/R/census_geo_api.R
@@ -103,7 +103,9 @@ census_geo_api <- function(key, state, geo = "tract", age = FALSE, sex = FALSE, 
     county_df <- get_census_api("https://api.census.gov/data/2010/dec/sf1?", key = key, vars = vars, region = region_county, retry)
     county_list <- county_df$county
     census <- NULL
-    county_list <- check_temp_save(county_list, save_temp, census)
+    temp <- check_temp_save(county_list, save_temp, census)
+    county_list <- temp$county_list
+    census <- temp$census
     
     for (c in 1:length(county_list)) {
       print(paste("County ", c, " of ", length(county_list), ": ", county_list[c], sep = ""))
@@ -125,7 +127,9 @@ census_geo_api <- function(key, state, geo = "tract", age = FALSE, sex = FALSE, 
     county_df <- get_census_api("https://api.census.gov/data/2010/dec/sf1?", key = key, vars = vars, region = region_county, retry)
     county_list <- county_df$county
     census <- NULL
-    county_list <- check_temp_save(county_list, save_temp, census)
+    temp <- check_temp_save(county_list, save_temp, census)
+    county_list <- temp$county_list
+    census <- temp$census
     
     for (c in 1:length(county_list)) {
       print(paste("County ", c, " of ", length(county_list), ": ", county_list[c], sep = ""))
@@ -262,5 +266,5 @@ check_temp_save <- function(county_list, save_temp, census) {
       message("Results will be saved in the specified temporary file.")
     }
   }
-  return(county_list)
+  return(county_list, census)
 }

--- a/R/census_geo_api.R
+++ b/R/census_geo_api.R
@@ -110,6 +110,9 @@ census_geo_api <- function(key, state, geo = "tract", age = FALSE, sex = FALSE, 
       region_county <- paste("for=tract:*&in=state:", state.fips, "+county:", county_list[c], sep = "")
       census.temp <- get_census_api("https://api.census.gov/data/2010/dec/sf1?", key = key, vars = vars, region = region_county, retry)
       census <- rbind(census, census.temp)
+      if (!is.null(save_temp)) {
+        save(census, file = save_temp)
+      }
     }
     rm(census.temp)
   }
@@ -138,6 +141,9 @@ census_geo_api <- function(key, state, geo = "tract", age = FALSE, sex = FALSE, 
         region_block <- paste("for=block:*&in=state:", state.fips, "+county:", county_list[c], "+tract:", tract_list[t], sep = "")
         census.temp <- get_census_api("https://api.census.gov/data/2010/dec/sf1?", key = key, vars = vars, region = region_block, retry)
         census <- rbind(census, census.temp)
+      }
+      if (!is.null(save_temp)) {
+        save(census, file = save_temp)
       }
     }
     

--- a/R/census_geo_api.R
+++ b/R/census_geo_api.R
@@ -266,5 +266,5 @@ check_temp_save <- function(county_list, save_temp, census) {
       message("Results will be saved in the specified temporary file.")
     }
   }
-  return(county_list, census)
+  return(list(county_list = county_list, census = census))
 }


### PR DESCRIPTION
Hello,
Thank you for maintaining a great package. 

The `census_geo_api` would often fail in the middle for more granular districts for very large states---for example, if I was calling with `geo = "block"` and `state = "CA"`. The end result somehow ends up in an infinite loop of 

> Error in file(con, "r") : all connections are in use

Not sure why the error occurs, because there is no explicit connection that is not being closed, and `readLines` in `get_census_api_2.R` should be taking care of closing all connections on exit. Embedding base `closeAllConnections` will probably do more harm than good. 

So I wrote an augmentation of `census_geo_api` for a quick workaround---which is to simply save intermediary outputs in a temporary file, so that when the process is interrupted, you will not lose the output altogether. Specifying `save_temp` will look for the temporary file, and if it does not exist, will start saving in the specified file path/name. 

The function can be buttressed by writing a bunch of checks (e.g. is `save_temp` going to be a valid R save format? Can we also save the intermediate output between a tract loop?), although I didn't input these details yet. One thing that would be nice to add is to make the temporary file a list instead of `census` dataframe, if eventually the `census_geo_api.R` function will move from a loop-`rbind` to a more efficient `do.call(rbind, list(census_list))`, in which `census_list` is a list of all outputs from `get_census_api`. 

Let me know what you think.
