### PR TITLE
Adjustments from discussion with Santiago

### DIFF
--- a/R/merge_names.R
+++ b/R/merge_names.R
@@ -89,7 +89,7 @@ merge_names <- function(voter.file, namesToUse, census.surname, table.surnames =
   }
 
   wru_data_preflight()
-  path <- ifelse(getOption("wru_data_wd"), getwd(), tempdir())
+  path <- ifelse(getOption("wru_data_wd", default = FALSE), getwd(), tempdir())
   
   first_c <- readRDS(paste0(path, "/wru-data-first_c.rds"))
   mid_c <- readRDS(paste0(path, "/wru-data-mid_c.rds"))
@@ -340,6 +340,6 @@ merge_names <- function(voter.file, namesToUse, census.surname, table.surnames =
 #'
 #' @importFrom piggyback pb_download
 wru_data_preflight <- function() {
-  dest <- ifelse(getOption("wru_data_wd"), getwd(), tempdir())
+  dest <- ifelse(getOption("wru_data_wd", default = FALSE), getwd(), tempdir())
   piggyback::pb_download(repo = "kosukeimai/wru", dest = dest)
 }

--- a/R/race_prediction_funs.R
+++ b/R/race_prediction_funs.R
@@ -300,7 +300,7 @@ predict_race_new <- function(voter.file, names.to.use, year = "2010",age = FALSE
   
   ## Preliminary Data quality checks
   wru_data_preflight()
-  path <- ifelse(getOption("wru_data_wd"), getwd(), tempdir())
+  path <- ifelse(getOption("wru_data_wd", default = FALSE), getwd(), tempdir())
   
   first_c <- readRDS(paste0(path, "/wru-data-first_c.rds"))
   mid_c <- readRDS(paste0(path, "/wru-data-mid_c.rds"))
@@ -451,7 +451,7 @@ predict_race_me <- function(voter.file, names.to.use, year = "2010",age = FALSE,
   
   ## Preliminary Data quality checks
   wru_data_preflight()
-  path <- ifelse(getOption("wru_data_wd"), getwd(), tempdir())
+  path <- ifelse(getOption("wru_data_wd", default = FALSE), getwd(), tempdir())
   
   if(census.surname){
     last_c <- readRDS(paste0(path, "/wru-data-census_last_c.rds"))


### PR DESCRIPTION
Should fix an issue where if option("wru_data_wd") is not set, a code failure could occur. Sets default to FALSE. The behavior of which  creates a temporary directory that lasts for the life of the R session. If the option is set to TRUE, the name data is downloaded instead into the working directory of the user. 

It will be desirable to set this option so we should add it to the workflow explanation in the readme.