### PR TITLE
Ensure unique counties from larger voterfiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: wru
-Version: 1.0.0009
+Version: 1.0.0010
 Date: 2022-07-26
 Title: Who are You? Bayesian Prediction of Racial Category Using Surname, First Name, Middle Name, and
     Geolocation

--- a/R/predict_race.R
+++ b/R/predict_race.R
@@ -187,6 +187,7 @@ predict_race <- function(voter.file, census.surname = TRUE, surname.only = FALSE
     voter.file$state <- toupper(voter.file$state)
     states <- unique(voter.file$state)
     county.list <- split(voter.file$county, voter.file$state)
+    county.list <- lapply(county.list, function(x) unique(x))
     census.data <- get_census_data(
       census.key, states, age, 
       sex, year, census.geo, 


### PR DESCRIPTION
When pulling census data as part of our predict_race call, the counties are split into groups by state. However, duplicates are left over. This is carried through in get_census_geo, causing the link for the initial county level pull to contain duplicated counties and the census data API to fail. 

Added a line to call unique on each states' counties before passing it to the initial census data pull. 

This should fix #72 