### PR TITLE
nudge citations to wru

### DIFF
--- a/R/wru-internal
+++ b/R/wru-internal
@@ -1,0 +1,7 @@
+.onAttach <- 
+function(libname, pkgname) {
+  packageStartupMessage("\nPlease cite as: \n")
+  packageStartupMessage("Khanna K, Bertelsen B, Olivella S, Rosenman E, Imai K (2022). wru: Who are You?")
+  packageStartupMessage("Bayesian Prediction of Racial Category Using Surname, First Name, Middle Name, and Geolocation.")
+  packageStartupMessage("URL: https://CRAN.R-project.org/package=wru \n")
+}


### PR DESCRIPTION
I noticed that Marek has (rightly) more than 1k citations to stargazer. https://scholar.google.com/citations?user=jRCc4kMAAAAJ&hl=en  I think one of the reasons is that the package produces a message onAttach to remind the user to cite the package. 

https://github.com/cran/stargazer/blob/master/R/stargazer-internal.R

I have made a similar change here. 

I think there is a larger point here about increasing citations to software to improve incentives for software producers and also make sure concerns in software can be backtraced from papers that rely on it.