### PR TITLE
Allow `age` and `sex` to be `TRUE` in `census_helper_new()`

### DIFF
--- a/R/census_helper_v2.R
+++ b/R/census_helper_v2.R
@@ -82,9 +82,6 @@ census_helper_new <- function(
   if(!(year %in% c("2000","2010","2020"))){
     stop("Interface only implemented for census years '2000', '2010', or '2020'.")
   }
-  if (any(age, sex)){
-    stop("Models using age and sex not currently implemented.")
-  }
   
   if (is.null(census.data) || (typeof(census.data) != "list")) {
     toDownload = TRUE


### PR DESCRIPTION
Remove check that errors if `age` or `sex` are `TRUE`, since `age` and `sex` are now supported.