### PR TITLE
Fix eBISG embedding of unmatched non-hyphenated surnames

### DIFF
--- a/R/race_prediction_funs.R
+++ b/R/race_prediction_funs.R
@@ -859,13 +859,22 @@ predict_race_embedding <- function(
   }
   known_surnames <- toupper(last_dict[[1]])  # first column is the name
 
-  ## Identify unmatched surnames: those whose cleaned match is not in the dictionary
-  ## merge_names applies a 6-step cleaning cascade; the lastname.match column
+  ## Initialized lazily on first use; both the surname and first-name
+  ## blocks below check is.null(model_dir) to avoid double-downloading.
+  model_dir <- NULL
 
-  ## reflects the final cleaned form that was looked up
-  cleaned_surnames <- toupper(voter.file$lastname.match)
-  unmatched_mask <- !(cleaned_surnames %in% known_surnames)
-  n_unmatched <- sum(unmatched_mask)
+  ## Identify unmatched surnames via merge_names' final scratchpad. The
+  ## scratchpad is only used for the matched/unmatched decision; the text
+  ## handed to the embedding model must come from the original surname
+  ## column, since merge_names overwrites lastname.match during cleaning
+  ## (a non-hyphenated unmatched name ends up as the literal string "NA").
+  cleaned_surnames  <- toupper(voter.file$lastname.match)
+  original_surnames <- toupper(as.character(voter.file$surname))
+  unmatched_mask    <- !(cleaned_surnames %in% known_surnames)
+  embed_mask        <- unmatched_mask &
+                       !is.na(original_surnames) &
+                       original_surnames != ""
+  n_unmatched <- sum(embed_mask)
 
   if (n_unmatched > 0) {
     ## Check Python dependencies and download model weights
@@ -878,43 +887,48 @@ predict_race_embedding <- function(
       "Using ", cfg$transformer, " embeddings for these names."
     )
 
-    ## Get unique unmatched surnames to avoid redundant embedding
-    unmatched_surnames <- unique(cleaned_surnames[unmatched_mask])
-    unmatched_surnames <- unmatched_surnames[!is.na(unmatched_surnames) & unmatched_surnames != ""]
+    ## Embed the original surname text (not the cascade scratchpad) so each
+    ## row gets a name-specific prediction.
+    unmatched_surnames <- unique(original_surnames[embed_mask])
 
-    if (length(unmatched_surnames) > 0) {
-      ## Embed and predict
-      message("Embedding ", length(unmatched_surnames), " unique unmatched surnames...")
-      embeddings <- ebisg_embed_names(unmatched_surnames, transformer = cfg$transformer)
-      mlp_path <- if (is.null(cfg$tag)) cfg$surname_mlp else file.path(model_dir, cfg$surname_mlp)
-      probs_6 <- ebisg_predict_mlp(embeddings, mlp_path)
-      probs_5 <- map_6class_to_5class(probs_6)
+    message("Embedding ", length(unmatched_surnames), " unique unmatched surnames...")
+    embeddings <- ebisg_embed_names(unmatched_surnames, transformer = cfg$transformer)
+    mlp_path   <- if (is.null(cfg$tag)) cfg$surname_mlp else file.path(model_dir, cfg$surname_mlp)
+    probs_6    <- ebisg_predict_mlp(embeddings, mlp_path)
+    probs_5    <- map_6class_to_5class(probs_6)
 
-      ## Build lookup: surname -> 5-class probabilities
-      sn_lookup <- as.data.frame(probs_5)
-      rownames(sn_lookup) <- unmatched_surnames
+    sn_lookup <- as.data.frame(probs_5)
+    rownames(sn_lookup) <- unmatched_surnames
 
-      ## Override imputed values for unmatched rows
-      for (k in seq_along(eth)) {
-        col_name <- paste0("c_", eth[k], "_last")
-        voter.file[[col_name]][unmatched_mask] <-
-          sn_lookup[cleaned_surnames[unmatched_mask], paste0("c_", eth[k])]
-      }
+    ## Override imputed values for embeddable unmatched rows. Rows excluded
+    ## from embed_mask (NA / empty original surname) keep merge_names'
+    ## column-mean fallback rather than getting NA written over them.
+    for (k in seq_along(eth)) {
+      col_name <- paste0("c_", eth[k], "_last")
+      voter.file[[col_name]][embed_mask] <-
+        sn_lookup[original_surnames[embed_mask], paste0("c_", eth[k])]
     }
   } else {
     message("eBISG: All surnames matched Census list.")
   }
 
-  ## Also handle unmatched first names with embedding if requested
+  ## Also handle unmatched first names with embedding if requested. Same
+  ## logic as the surname block: the cleaning scratchpad decides which
+  ## rows are unmatched, but the text we embed comes from the original
+  ## first-name column.
   if (grepl("first", names.to.use) && !is.null(cfg$firstname_mlp)) {
     first_dict <- readRDS(paste0(path, "/wru-data-first_c.rds"))
-    known_firstnames <- toupper(first_dict[[1]])
-    cleaned_firstnames <- toupper(voter.file$firstname.match)
+    known_firstnames    <- toupper(first_dict[[1]])
+    cleaned_firstnames  <- toupper(voter.file$firstname.match)
+    original_firstnames <- toupper(as.character(voter.file$first))
     unmatched_first_mask <- !(cleaned_firstnames %in% known_firstnames)
-    n_unmatched_first <- sum(unmatched_first_mask)
+    embed_first_mask     <- unmatched_first_mask &
+                            !is.na(original_firstnames) &
+                            original_firstnames != ""
+    n_unmatched_first <- sum(embed_first_mask)
 
     if (n_unmatched_first > 0) {
-      if (!exists("model_dir")) {
+      if (is.null(model_dir)) {
         ensure_ebisg_python()
         model_dir <- ebisg_data_preflight(cfg)
       }
@@ -925,23 +939,20 @@ predict_race_embedding <- function(
         "Using ", cfg$transformer, " embeddings."
       )
 
-      unmatched_firstnames <- unique(cleaned_firstnames[unmatched_first_mask])
-      unmatched_firstnames <- unmatched_firstnames[!is.na(unmatched_firstnames) & unmatched_firstnames != ""]
+      unmatched_firstnames <- unique(original_firstnames[embed_first_mask])
 
-      if (length(unmatched_firstnames) > 0) {
-        embeddings_fn <- ebisg_embed_names(unmatched_firstnames, transformer = cfg$transformer)
-        fn_mlp_path <- if (is.null(cfg$tag)) cfg$firstname_mlp else file.path(model_dir, cfg$firstname_mlp)
-        probs_6_fn <- ebisg_predict_mlp(embeddings_fn, fn_mlp_path)
-        probs_5_fn <- map_6class_to_5class(probs_6_fn)
+      embeddings_fn <- ebisg_embed_names(unmatched_firstnames, transformer = cfg$transformer)
+      fn_mlp_path   <- if (is.null(cfg$tag)) cfg$firstname_mlp else file.path(model_dir, cfg$firstname_mlp)
+      probs_6_fn    <- ebisg_predict_mlp(embeddings_fn, fn_mlp_path)
+      probs_5_fn    <- map_6class_to_5class(probs_6_fn)
 
-        fn_lookup <- as.data.frame(probs_5_fn)
-        rownames(fn_lookup) <- unmatched_firstnames
+      fn_lookup <- as.data.frame(probs_5_fn)
+      rownames(fn_lookup) <- unmatched_firstnames
 
-        for (k in seq_along(eth)) {
-          col_name <- paste0("c_", eth[k], "_first")
-          voter.file[[col_name]][unmatched_first_mask] <-
-            fn_lookup[cleaned_firstnames[unmatched_first_mask], paste0("c_", eth[k])]
-        }
+      for (k in seq_along(eth)) {
+        col_name <- paste0("c_", eth[k], "_first")
+        voter.file[[col_name]][embed_first_mask] <-
+          fn_lookup[original_firstnames[embed_first_mask], paste0("c_", eth[k])]
       }
     }
   }

--- a/tests/testthat/test-ebisg-bug-repro.R
+++ b/tests/testthat/test-ebisg-bug-repro.R
@@ -1,0 +1,104 @@
+## Regression tests for eBISG handling of unmatched surnames.
+##
+## These guard against re-introducing the bug where merge_names'
+## cleaning cascade overwrites lastname.match for non-hyphenated
+## unmatched names (it leaves the literal string "NA" in that column),
+## which previously caused predict_race_embedding to embed the token
+## "NA" instead of the actual surname text — collapsing every distinct
+## non-hyphenated unmatched surname to the same garbage prediction.
+##
+## We mock the embedding/MLP calls so the tests exercise the real
+## predict_race_embedding code path without needing Python deps or a
+## downloaded MLP checkpoint.
+
+with_mocked_ebisg <- function(code) {
+  embed_calls <- character(0)
+  testthat::local_mocked_bindings(
+    ensure_ebisg_python  = function(...) invisible(),
+    ebisg_data_preflight = function(...) tempdir(),
+    ebisg_embed_names    = function(names, ...) {
+      embed_calls <<- c(embed_calls, names)
+      ## Return a deterministic per-name vector so distinct inputs
+      ## produce distinct (downstream) outputs.
+      matrix(seq_along(names), nrow = length(names), ncol = 4L)
+    },
+    ebisg_predict_mlp = function(embeddings, ...) {
+      n <- nrow(embeddings)
+      ## Distinct softmax distributions per input row, normalized.
+      raw <- matrix(seq_len(n * 6L), nrow = n, ncol = 6L)
+      raw / rowSums(raw)
+    },
+    .package = "wru"
+  )
+  result <- code()
+  list(result = result, embed_calls = embed_calls)
+}
+
+test_that("eBISG embeds the original surname text, not merge_names' scratchpad", {
+  vf <- data.frame(
+    surname = c("SMITH", "ZQXWVPLM", "QQXWPLZZ"),
+    state   = "NJ",
+    stringsAsFactors = FALSE
+  )
+  out <- with_mocked_ebisg(function() {
+    predict_race(voter.file = vf, surname.only = TRUE, model = "eBISG")
+  })
+
+  ## The fix: original surnames flow into the embedding step. The bug
+  ## would have sent the literal token "NA" instead.
+  expect_true(all(c("ZQXWVPLM", "QQXWPLZZ") %in% out$embed_calls))
+  expect_false("NA" %in% out$embed_calls)
+})
+
+test_that("eBISG keeps unique unmatched surnames distinct in the embedding step", {
+  ## Pre-fix, two different non-hyphenated unmatched surnames both
+  ## collapsed to lastname.match = "NA" and so produced one embedding
+  ## input shared across all such rows.
+  vf <- data.frame(
+    surname = c("ZQXWVPLM", "QQXWPLZZ"),
+    state   = "NJ",
+    stringsAsFactors = FALSE
+  )
+  out <- with_mocked_ebisg(function() {
+    predict_race(voter.file = vf, surname.only = TRUE, model = "eBISG")
+  })
+  expect_setequal(out$embed_calls, c("ZQXWVPLM", "QQXWPLZZ"))
+})
+
+test_that("eBISG produces finite, normalized predictions for unmatched non-hyphenated surnames", {
+  vf <- data.frame(
+    surname = c("SMITH", "FAKE-NAME", "ZQXWVPLM"),
+    state   = "NJ",
+    stringsAsFactors = FALSE
+  )
+  out <- with_mocked_ebisg(function() {
+    predict_race(voter.file = vf, surname.only = TRUE, model = "eBISG")
+  })
+  pred_cols <- grep("^pred\\.", names(out$result), value = TRUE)
+  expect_equal(length(pred_cols), 5L)
+  expect_false(any(is.na(out$result[, pred_cols])))
+  expect_false(any(is.nan(as.matrix(out$result[, pred_cols]))))
+  expect_equal(
+    unname(rowSums(out$result[, pred_cols])),
+    rep(1, nrow(vf)),
+    tolerance = 1e-6
+  )
+})
+
+test_that("eBISG skips rows with NA / empty surname rather than overriding with NA", {
+  vf <- data.frame(
+    surname = c("SMITH", NA_character_, ""),
+    state   = "NJ",
+    stringsAsFactors = FALSE
+  )
+  ## merge_names rejects NA surnames at validation, so we restrict to the
+  ## empty-string case here, which it accepts.
+  vf <- vf[vf$surname %in% c("SMITH", "") | is.na(vf$surname), ]
+  vf <- vf[!is.na(vf$surname), ]
+  out <- with_mocked_ebisg(function() {
+    predict_race(voter.file = vf, surname.only = TRUE, model = "eBISG")
+  })
+  expect_false("" %in% out$embed_calls)
+  pred_cols <- grep("^pred\\.", names(out$result), value = TRUE)
+  expect_false(any(is.na(out$result[, pred_cols])))
+})


### PR DESCRIPTION
The cleaning cascade overwrites that column with the literal string "NA" for non-hyphenated unmatched surnames, so every such row collapsed to the same garbage prediction. Use voter.file$surname (uppercased) for the embedding text. Leep lastname.match only for the matched/unmatched decision.