### PR TITLE
Point eBISG model registry at v3.1.0 release tag

### DIFF
--- a/R/ebisg_utils.R
+++ b/R/ebisg_utils.R
@@ -38,7 +38,7 @@ ebisg_model_registry <- list(
     dim = 1024L,
     surname_mlp = "ebisg-surname-mlp.pt",
     firstname_mlp = "ebisg-firstname-mlp.pt",
-    tag = "v3.1.0"
+    tag = "v3.1.1"
   )
 )
 

--- a/R/ebisg_utils.R
+++ b/R/ebisg_utils.R
@@ -39,7 +39,7 @@ ebisg_model_registry <- list(
     surname_mlp = "ebisg-surname-mlp.pt",
     firstname_mlp = "ebisg-firstname-mlp.pt",
     fullname_mlp = "ebisg-fullname-mlp.pt",
-    tag = "ebisg-v1.0"
+    tag = "v3.1.0"
   )
 )
 

--- a/R/ebisg_utils.R
+++ b/R/ebisg_utils.R
@@ -38,7 +38,6 @@ ebisg_model_registry <- list(
     dim = 1024L,
     surname_mlp = "ebisg-surname-mlp.pt",
     firstname_mlp = "ebisg-firstname-mlp.pt",
-    fullname_mlp = "ebisg-fullname-mlp.pt",
     tag = "v3.1.0"
   )
 )

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ predict_race(
 ```
 
 For methodological details, see Dasanaike and Imai (2026),
-“Embedding-Supplemented Bayesian Improved Surname Geocoding.”
+“Using Embedding Models to Improve Probabilistic Race Prediction.”
 
 ### Downloading census data
 


### PR DESCRIPTION
Now that PR #167 has been merged and tagged v3.1.0, this updates ebisg_model_registry to download from the v3.1.0 release (instead of the placeholder ebisg-v1.0 tag) and removes the unused fullname_mlp entry.