### PR TITLE
Warn that `party` has no effect on predictions, and correct the docs

### DIFF
--- a/R/predict_race.R
+++ b/R/predict_race.R
@@ -4,7 +4,7 @@
 #'
 #' This function implements the Bayesian race prediction methods outlined in
 #' Imai and Khanna (2015). The function produces probabilistic estimates of
-#' individual-level race/ethnicity, based on surname, geolocation, and party.
+#' individual-level race/ethnicity, based on surname and geolocation.
 #' @param voter.file An object of class \code{data.frame}.
 #' Must contain a row for each individual being predicted,
 #' as well as a field named \code{\var{surname}} containing each individual's surname.
@@ -67,12 +67,11 @@
 #' where \code{\var{sex}} is coded as 0 for males and 1 for females.
 #' @param year An optional character vector specifying the year of U.S. Census geographic
 #' data to be downloaded. Use \code{"2010"}, or \code{"2020"}. Default is \code{"2020"}.
-#' @param party An optional character object specifying party registration field
-#' in \code{\var{voter.file}}, e.g., \code{\var{party} = "PartyReg"}.
-#' If specified, race/ethnicity predictions will be conditioned
-#' on individual's party registration (in addition to geolocation).
-#' Whatever the name of the party registration field in \code{\var{voter.file}},
-#' it should be coded as 1 for Democrat, 2 for Republican, and 0 for Other.
+#' @param party Deprecated and currently has no effect. Party registration was
+#' used to condition the priors by the pre-2.0 implementation
+#' (\code{.predict_race_old}), which the "BISG", "fBISG" and "eBISG" models
+#' replaced; none of them accept it. Supplying it now raises a warning and the
+#' predictions are unchanged.
 #' @param retry The number of retries at the census website if network interruption occurs.
 #' @param impute.missing Logical, defaults to TRUE. Should missing be imputed?
 #' @param skip_bad_geos Logical. Option to have the function skip any geolocations that are not present 
@@ -135,7 +134,7 @@
 #' \dontrun{
 #' CensusObj <- try(get_census_data(state = c("NY", "DC", "NJ")))
 #' try(predict_race(
-#'   voter.file = voters, census.geo = "tract", census.data = CensusObj, party = "PID")
+#'   voter.file = voters, census.geo = "tract", census.data = CensusObj)
 #'   )
 #' }
 #' \dontrun{
@@ -175,7 +174,18 @@ predict_race <- function(
 ) {
   
   message("Predicting race for ", year)
-  
+
+  ## `party` is not consumed by any of the current models. Warn rather than
+  ## accept it silently, so a caller expecting party-conditioned priors is not
+  ## misled by predictions that ignored the argument entirely.
+  if (!is.null(party)) {
+    warning(
+      "`party` is not used by the BISG, fBISG or eBISG models and has no ",
+      "effect on predictions. It was only used by the pre-2.0 implementation. ",
+      "Predictions returned here are not conditioned on party registration."
+    )
+  }
+
   ## Check model type
   if (!(model %in% c("BISG", "fBISG", "eBISG"))) {
     stop(

--- a/man/predict_race.Rd
+++ b/man/predict_race.Rd
@@ -97,12 +97,11 @@ where \code{\var{sex}} is coded as 0 for males and 1 for females.}
 \item{year}{An optional character vector specifying the year of U.S. Census geographic
 data to be downloaded. Use \code{"2010"}, or \code{"2020"}. Default is \code{"2020"}.}
 
-\item{party}{An optional character object specifying party registration field
-in \code{\var{voter.file}}, e.g., \code{\var{party} = "PartyReg"}.
-If specified, race/ethnicity predictions will be conditioned
-on individual's party registration (in addition to geolocation).
-Whatever the name of the party registration field in \code{\var{voter.file}},
-it should be coded as 1 for Democrat, 2 for Republican, and 0 for Other.}
+\item{party}{Deprecated and currently has no effect. Party registration was
+used to condition the priors by the pre-2.0 implementation
+(\code{.predict_race_old}), which the "BISG", "fBISG" and "eBISG" models
+replaced; none of them accept it. Supplying it now raises a warning and the
+predictions are unchanged.}
 
 \item{retry}{The number of retries at the census website if network interruption occurs.}
 
@@ -168,7 +167,7 @@ predicted probabilities for each of the five major racial categories:
 \details{
 This function implements the Bayesian race prediction methods outlined in
 Imai and Khanna (2015). The function produces probabilistic estimates of
-individual-level race/ethnicity, based on surname, geolocation, and party.
+individual-level race/ethnicity, based on surname and geolocation.
 }
 \examples{
 \donttest{
@@ -184,7 +183,7 @@ try(predict_race(
 \dontrun{
 CensusObj <- try(get_census_data(state = c("NY", "DC", "NJ")))
 try(predict_race(
-  voter.file = voters, census.geo = "tract", census.data = CensusObj, party = "PID")
+  voter.file = voters, census.geo = "tract", census.data = CensusObj)
   )
 }
 \dontrun{

--- a/tests/testthat/test-party-deprecated.R
+++ b/tests/testthat/test-party-deprecated.R
@@ -1,0 +1,35 @@
+test_that("supplying `party` warns that it has no effect", {
+  voters <- data.frame(
+    surname = c("Smith", "Nguyen", "Garcia"),
+    state = "NJ", county = "021", tract = "007000",
+    PID = c(1, 2, 0),
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    suppressMessages(
+      predict_race(voter.file = voters, surname.only = TRUE, party = "PID")
+    ),
+    "no effect"
+  )
+})
+
+test_that("`party` does not change predictions", {
+  # The argument was silently ignored rather than applied. Pin that the
+  # predictions are identical, so that if party is ever wired back into the
+  # current models this test fails and has to be revisited deliberately.
+  voters <- data.frame(
+    surname = c("Smith", "Nguyen", "Garcia"),
+    state = "NJ", county = "021", tract = "007000",
+    PID = c(1, 2, 0),
+    stringsAsFactors = FALSE
+  )
+
+  a <- suppressMessages(predict_race(voter.file = voters, surname.only = TRUE))
+  b <- suppressWarnings(suppressMessages(
+    predict_race(voter.file = voters, surname.only = TRUE, party = "PID")
+  ))
+
+  cols <- grep("^pred", names(a), value = TRUE)
+  expect_equal(a[cols], b[cols])
+})


### PR DESCRIPTION
`predict_race()` accepts a `party` argument, documented as conditioning the race/ethnicity predictions on party registration. It currently has no effect: the argument is never read, and predictions are returned unchanged with no indication that it was ignored.

The only function that consumed it, `.predict_race_old()`, is not called by `predict_race()`, and none of the three current back ends (`predict_race_new`, `predict_race_me`, `predict_race_embedding`) take the argument.

```r
library(wru)
"party" %in% names(formals(predict_race))                              # TRUE
grepl("\\bparty\\b", paste(deparse(body(predict_race)), collapse=" ")) # FALSE
```

## Reproduction

```r
v <- data.frame(surname = c("Smith","Nguyen","Garcia","Washington","Kim"),
                state = "NJ", county = "021", tract = "007000",
                PID = 1)

a <- predict_race(voter.file = v, surname.only = TRUE)
b <- predict_race(voter.file = v, surname.only = TRUE, party = "PID")

all.equal(a[grep("^pred", names(a))], b[grep("^pred", names(b))])   # TRUE
```

Identical predictions, no warning.

## What this changes

I have deliberately **not** tried to wire party priors into the current models. Whether `party` should come back is a modelling decision, and porting `.predict_race_old()`'s prior logic into the BISG/fBISG/eBISG path on my reading of intent would not be appropriate — this package is used in settings where the numbers matter a great deal.

So this PR only makes the current behaviour honest, which is correct either way:

- `predict_race()` warns when `party` is non-`NULL`, saying it has no effect on predictions;
- the `@param party` documentation says it is deprecated and currently inert, instead of describing conditioning that does not happen;
- the function description no longer claims predictions are "based on surname, geolocation, and party";
- the `\dontrun` example no longer passes `party = "PID"`.

If you would rather party registration were reinstated in the current models, I am happy to look at that as a follow-up — it just seemed wrong to guess.

## Verification

`tests/testthat/test-party-deprecated.R` covers both the warning and the fact that predictions are unchanged. The second assertion is there deliberately so that if party is ever wired back in, the test fails and forces a conscious revisit.

- New tests: fail on current `main` (1 failure), pass with this change.
- Existing suite: **19 failures / 41 passes before, 18 / 42 after** — the single difference is the new test flipping to pass. The other 18 failures are pre-existing on `main` and unrelated (they appear to need network/Census access).
- Only `R/predict_race.R` and the regenerated `man/predict_race.Rd` are touched; I reverted the unrelated roxygen churn so the diff stays minimal (your `RoxygenNote` is untouched).
