### PR TITLE
Rebaseline test fixtures on the 2020 Census surname dictionary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # wru (development version)
 
+* Surname priors now come from the 2020 Census names files. The
+  `wru-data-census_last_c.rds` dictionary on the v4.0.0 release replaces the
+  2010-vintage table used since v2.0.0, and a Census first-name dictionary
+  (`wru-data-census_first_c.rds`) is published for the first time. Predictions
+  move for every name. The 2020 table covers 156,621 surnames against the 2010
+  table's 162,253, and shifts probability mass toward the Hispanic and
+  multi-race categories. `year` selects Census geography only: the name
+  dictionaries are always the newest vintage, so `year = "2010"` combines 2010
+  geography with 2020 name priors.
 * `format_legacy_data()` now returns an object `predict_race()` can consume, and
   its output changes shape as a result (#175). It is keyed by state and carries
   `state`/`age`/`sex`/`year` alongside the `county`, `tract`, `block_group` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
   multi-race categories. `year` selects Census geography only: the name
   dictionaries are always the newest vintage, so `year = "2010"` combines 2010
   geography with 2020 name priors.
+* A failed name-dictionary download now raises an error naming the files that
+  are missing and the release they were sought from. It previously emitted a
+  message and let execution continue, so the failure surfaced as `cannot open
+  the connection` from `readRDS()` well away from its cause. A download that
+  fails while usable copies are already on disk still reports the error and
+  proceeds.
 * `format_legacy_data()` now returns an object `predict_race()` can consume, and
   its output changes shape as a result (#175). It is keyed by state and carries
   `state`/`age`/`sex`/`year` alongside the `county`, `tract`, `block_group` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,20 +1,29 @@
 # wru (development version)
 
-* Surname priors now come from the 2020 Census names files. The
+* `predict_race()` gains a `name_source` argument. It selects the dictionaries
+  that supply the name probabilities. The default `"mixed"` combines the Census
+  and voter-file dictionaries. For a name that both hold, the Census
+  probabilities win, and the voter-file dictionary supplies every other name.
+  `"census_only"` uses the Census dictionaries alone, and `"vf_only"` uses the
+  voter-file dictionaries alone. There is no Census middle-name dictionary, so
+  `"census_only"` raises an error for middle names.
+* `census.surname` is deprecated in favor of `name_source`, and its default is
+  now `NULL`. A supplied value still works and raises a warning. `TRUE` maps to
+  `"mixed"`. `FALSE` maps to `"vf_only"`.
+* Surname probabilities now come from the 2020 Census names files. The
   `wru-data-census_last_c.rds` dictionary on the v4.0.0 release replaces the
-  2010-vintage table used since v2.0.0, and a Census first-name dictionary
+  2010-vintage dictionary used since v2.0.0. A Census first-name dictionary
   (`wru-data-census_first_c.rds`) is published for the first time. Predictions
-  move for every name. The 2020 table covers 156,621 surnames against the 2010
-  table's 162,253, and shifts probability mass toward the Hispanic and
-  multi-race categories. `year` selects Census geography only: the name
-  dictionaries are always the newest vintage, so `year = "2010"` combines 2010
-  geography with 2020 name priors.
-* A failed name-dictionary download now raises an error naming the files that
-  are missing and the release they were sought from. It previously emitted a
-  message and let execution continue, so the failure surfaced as `cannot open
-  the connection` from `readRDS()` well away from its cause. A download that
-  fails while usable copies are already on disk still reports the error and
-  proceeds.
+  move for every name, because the 2020 dictionary holds 156,621 surnames
+  against 162,253 in the 2010 dictionary. Probability mass moves toward the
+  Hispanic and multi-race categories. `year` selects Census geography only, so
+  `year = "2010"` combines 2010 geography with 2020 name probabilities.
+* A failed name-dictionary download now raises an error. The error names the
+  files that are missing and the release that holds them. The download
+  previously printed a message and let execution continue. The failure then
+  appeared as `cannot open the connection` from `readRDS()`, far from its
+  cause. If usable copies are already on disk, a failed download reports the
+  error and continues.
 * `format_legacy_data()` now returns an object `predict_race()` can consume, and
   its output changes shape as a result (#175). It is keyed by state and carries
   `state`/`age`/`sex`/`year` alongside the `county`, `tract`, `block_group` and

--- a/R/merge_names.R
+++ b/R/merge_names.R
@@ -330,9 +330,33 @@ merge_names <- function(voter.file, namesToUse, name_source = "mixed", year = "2
 #' @importFrom piggyback pb_download
 wru_data_preflight <- function() {
   dest <- ifelse(getOption("wru_data_wd", default = FALSE), getwd(), tempdir())
+  tag <- "v4.0.0"
+  err <- NULL
   tryCatch(
     # Oddity of conditions for .token. Ignores token if is ""
-    piggyback::pb_download(repo = "kosukeimai/wru", dest = dest, .token = "", tag = "v4.0.0"), 
-    error = function(e) message("There was an error retrieving data: ", e$message)
+    pb_download(repo = "kosukeimai/wru", dest = dest, .token = "", tag = tag),
+    error = function(e) err <<- conditionMessage(e)
   )
+
+  # Every prediction path reads these two. Without them the callers fail later
+  # inside readRDS() with "cannot open the connection", which says nothing about
+  # the download that actually failed.
+  core <- c("wru-data-census_last_c.rds", "wru-data-last_c.rds")
+  absent <- core[!file.exists(file.path(dest, core))]
+  if (length(absent) > 0) {
+    stop("Could not obtain the wru name dictionaries from the ", tag,
+         " release of kosukeimai/wru.\n",
+         "  missing:   ", paste(absent, collapse = ", "), "\n",
+         "  looked in: ", dest, "\n",
+         if (is.null(err)) "" else paste0("  download error: ", err, "\n"),
+         "Check your network connection and GitHub rate limit, then try again.",
+         call. = FALSE)
+  }
+
+  # Download failed but usable copies are already on disk, so this is not fatal.
+  if (!is.null(err)) {
+    message("There was an error retrieving data: ", err,
+            "\nUsing the copies already in ", dest, ".")
+  }
+  invisible(dest)
 }

--- a/tests/testthat/test-predict_race_2010.R
+++ b/tests/testthat/test-predict_race_2010.R
@@ -4,13 +4,15 @@
 options("piggyback.verbose" = FALSE)
 options("wru_data_wd" = TRUE)
 
-## v4.0.0: predict_race() defaults to name_source = "mixed", which unions the
-## Census and voter-file surname dictionaries with Census probabilities winning on
-## overlapping names. The expected values below are intentionally unchanged from the
-## previous census-surname default: every fixture surname is present in the Census
-## dictionary, so the union only adds coverage for names absent from Census (none
-## here) and matched names keep their Census-derived probabilities. A shift here
-## would mean the union/precedence logic regressed, not that the values are stale.
+## v4.0.0: the values below are baselined against the 2020 Census surname
+## dictionary (wru-data-census_last_c.rds on the v4.0.0 release), which replaced
+## the 2010-vintage table. `year` selects Census geography only -- the name
+## dictionaries are always the newest vintage, so this file and
+## test-predict_race_2020.R share the same surname priors.
+##
+## Replacing that dictionary moves every value here. If these fail after a
+## dictionary refresh, rebaseline them against the new table. If they fail
+## without one, the prediction path changed.
 
 test_that("Tests surname only predictions", {
   skip_on_cran()
@@ -24,8 +26,8 @@ test_that("Tests surname only predictions", {
   # Test and confirm prediction output is as expected
   expect_equal(dim(x), c(10, 20))
   expect_equal(sum(is.na(x)), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.045, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Johnson", "pred.his"], 4), 0.0272, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.057, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Johnson", "pred.his"], 4), 0.0358, tolerance = 0.01)
 })
 
 test_that("Test BISG NJ at county level", {
@@ -44,10 +46,10 @@ test_that("Test BISG NJ at county level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x)), 0L)
   expect_equal(sum(x$surname == "Johnson"), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.0314, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Khanna", "pred.asi"], 4), 0.9367, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Fifield", "pred.whi"], 4), 0.9230, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.9178, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.0397, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.asi"], 4), 0.9283, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Fifield", "pred.whi"], 4), 0.9128, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.9108, tolerance = 0.01)
 })
 
 test_that("Test fBISG NJ at tract level", {
@@ -70,8 +72,8 @@ test_that("Test fBISG NJ at tract level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x)), 0L)
   expect_equal(sum(x$surname == "Johnson"), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.063, tolerance = 0.01) # 0.0644
-  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.78, tolerance = 0.01) # 0.0644
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.08, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.769, tolerance = 0.01)
 })
 
 test_that("BISG NJ at block level", {
@@ -93,9 +95,9 @@ test_that("BISG NJ at block level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x$pred.asi)), 0L)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.7640, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 1.0, tolerance = 0.1)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.7, tolerance = 0.1)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.7273, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9951, tolerance = 0.1)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.6571, tolerance = 0.1)
 })
 
 test_that("BISG NJ at block_group level", {
@@ -119,9 +121,9 @@ test_that("BISG NJ at block_group level", {
   expect_equal(dim(x), c(7, 21))
   expect_equal(sum(is.na(x$pred.asi)), 0)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9183, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 1.0, tolerance = 0.01)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.75, tolerance = 0.01)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9087, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9780, tolerance = 0.01)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.7360, tolerance = 0.01)
 })
 
 test_that("Fails on territories", {
@@ -184,9 +186,9 @@ test_that("Handles zero-pop. geolocations", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x$pred.asi)), 0)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.91, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.99, tolerance = 0.01)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.92, tolerance = 0.01)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.8930, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9663, tolerance = 0.01)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.9124, tolerance = 0.01)
 })
 
 test_that("Fixes for issue #68 work as expected", {
@@ -201,11 +203,11 @@ test_that("Fixes for issue #68 work as expected", {
   surname <- c("SULLIVAN", "SULLIVAN", "SULLIVAN")
   three <- predict_race(voter.file=data.frame(surname), year = 2010, surname.only=TRUE)
   
-  expect_equal(one$pred.whi, 0.8397254)
-  expect_equal(two$pred.whi[1], 0.8397254)
-  expect_equal(two$pred.whi[2], 0.8397254)
+  expect_equal(one$pred.whi, 0.83252154)
+  expect_equal(two$pred.whi[1], 0.83252154)
+  expect_equal(two$pred.whi[2], 0.83252154)
   
-  expect_equal(three$pred.whi[1], 0.8397254)
-  expect_equal(three$pred.whi[2], 0.8397254)
-  expect_equal(three$pred.whi[3], 0.8397254)
+  expect_equal(three$pred.whi[1], 0.83252154)
+  expect_equal(three$pred.whi[2], 0.83252154)
+  expect_equal(three$pred.whi[3], 0.83252154)
 })

--- a/tests/testthat/test-predict_race_2020.R
+++ b/tests/testthat/test-predict_race_2020.R
@@ -4,13 +4,15 @@
 options("piggyback.verbose" = FALSE)
 options("wru_data_wd" = TRUE)
 
-## v4.0.0: predict_race() defaults to name_source = "mixed", which unions the
-## Census and voter-file surname dictionaries with Census probabilities winning on
-## overlapping names. The expected values below are intentionally unchanged from the
-## previous census-surname default: every fixture surname is present in the Census
-## dictionary, so the union only adds coverage for names absent from Census (none
-## here) and matched names keep their Census-derived probabilities. A shift here
-## would mean the union/precedence logic regressed, not that the values are stale.
+## v4.0.0: the values below are baselined against the 2020 Census surname
+## dictionary (wru-data-census_last_c.rds on the v4.0.0 release), which replaced
+## the 2010-vintage table. `year` selects Census geography only -- the name
+## dictionaries are always the newest vintage, so this file and
+## test-predict_race_2010.R share the same surname priors.
+##
+## Replacing that dictionary moves every value here. If these fail after a
+## dictionary refresh, rebaseline them against the new table. If they fail
+## without one, the prediction path changed.
 
 test_that("Fails if model is set to anything other than BISG or fBISG", {
   skip_on_cran()
@@ -35,8 +37,8 @@ test_that("Tests surname only predictions", {
   # Test and confirm prediction output is as expected
   expect_equal(dim(x), c(10, 20))
   expect_equal(sum(is.na(x)), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.045, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Johnson", "pred.his"], 4), 0.0272, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.057, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Johnson", "pred.his"], 4), 0.0358, tolerance = 0.01)
 })
 
 test_that("Test BISG NJ at county level", {
@@ -54,10 +56,10 @@ test_that("Test BISG NJ at county level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x)), 0L)
   expect_equal(sum(x$surname == "Johnson"), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.0181, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Khanna", "pred.asi"], 4), 0.9444, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Fifield", "pred.whi"], 4), 0.8664, tolerance = 0.01)
-  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.9392, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.0229, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Khanna", "pred.asi"], 4), 0.9415, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Fifield", "pred.whi"], 4), 0.8488, tolerance = 0.01)
+  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.9358, tolerance = 0.01)
 })
 
 test_that("Test fBISG NJ at tract level", {
@@ -79,8 +81,8 @@ test_that("Test fBISG NJ at tract level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x)), 0L)
   expect_equal(sum(x$surname == "Johnson"), 0)
-  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.031, tolerance = 0.01) 
-  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.798, tolerance = 0.01) 
+  expect_equal(round(x[x$surname == "Khanna", "pred.whi"], 4), 0.037, tolerance = 0.01) 
+  expect_equal(round(x[x$surname == "Lopez", "pred.his"], 4), 0.793, tolerance = 0.01) 
 })
 
 test_that("BISG NJ at block level", {
@@ -101,9 +103,9 @@ test_that("BISG NJ at block level", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x$pred.asi)), 0L)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.8078, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9926, tolerance = 0.1)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.8605, tolerance = 0.1)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.8358, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9838, tolerance = 0.1)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.8523, tolerance = 0.1)
 })
 
 test_that("BISG NJ at block_group level", {
@@ -126,9 +128,9 @@ test_that("BISG NJ at block_group level", {
   expect_equal(dim(x), c(7, 21))
   expect_equal(sum(is.na(x$pred.asi)), 0)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9374, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9954, tolerance = 0.01)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.8361, tolerance = 0.01)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9387, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9920, tolerance = 0.01)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.8346, tolerance = 0.01)
 })
 
 test_that("Fails on territories", {
@@ -188,9 +190,9 @@ test_that("Handles zero-pop. geolocations", {
   expect_equal(dim(x), c(7, 20))
   expect_equal(sum(is.na(x$pred.asi)), 0)
   expect_true(!any(duplicated(x$surname)))
-  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9444, tolerance = 0.01)
-  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9932, tolerance = 0.01)
-  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.9392, tolerance = 0.01)
+  expect_equal(x[x$surname == "Khanna", "pred.asi"], 0.9415, tolerance = 0.01)
+  expect_equal(x[x$surname == "Zhou", "pred.asi"], 0.9840, tolerance = 0.01)
+  expect_equal(x[x$surname == "Lopez", "pred.his"], 0.9358, tolerance = 0.01)
 })
 
 test_that("Fixes for issue #68 work as expected", {
@@ -205,11 +207,11 @@ test_that("Fixes for issue #68 work as expected", {
   surname <- c("SULLIVAN", "SULLIVAN", "SULLIVAN")
   three <- predict_race(voter.file=data.frame(surname), surname.only=TRUE)
   
-  expect_equal(one$pred.whi, 0.8397254)
-  expect_equal(two$pred.whi[1], 0.8397254)
-  expect_equal(two$pred.whi[2], 0.8397254)
+  expect_equal(one$pred.whi, 0.83252154)
+  expect_equal(two$pred.whi[1], 0.83252154)
+  expect_equal(two$pred.whi[2], 0.83252154)
   
-  expect_equal(three$pred.whi[1], 0.8397254)
-  expect_equal(three$pred.whi[2], 0.8397254)
-  expect_equal(three$pred.whi[3], 0.8397254)
+  expect_equal(three$pred.whi[1], 0.83252154)
+  expect_equal(three$pred.whi[2], 0.83252154)
+  expect_equal(three$pred.whi[3], 0.83252154)
 })

--- a/tests/testthat/test-wru-data-preflight.R
+++ b/tests/testthat/test-wru-data-preflight.R
@@ -1,0 +1,72 @@
+## wru_data_preflight() must fail loudly when the release data cannot be obtained.
+## Previously a failed pb_download() only emitted a message and execution carried
+## on into readRDS(), so the user saw `cannot open the connection` from gzfile()
+## deep in the stack rather than a statement of what failed.
+
+CORE <- c("wru-data-census_last_c.rds", "wru-data-last_c.rds")
+
+## Run `code` with the package pointed at an isolated, disposable data directory.
+## `code` is called with that directory as its only argument.
+with_data_dir <- function(name, files = character(), code) {
+  dir <- file.path(tempdir(), name)
+  unlink(dir, recursive = TRUE)
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  for (f in files) saveRDS(data.frame(), file.path(dir, f))
+
+  old_wd  <- setwd(dir)
+  old_opt <- options(wru_data_wd = TRUE)
+  on.exit({
+    setwd(old_wd)
+    options(old_opt)
+    unlink(dir, recursive = TRUE)
+  }, add = TRUE)
+
+  code(dir)
+}
+
+test_that("a failed download with no data on disk raises a clear error", {
+  with_data_dir("wru-preflight-empty", code = function(dir) {
+    local_mocked_bindings(
+      pb_download = function(...) stop("argument is of length zero"),
+      .package = "wru"
+    )
+    ## names the file that is missing, rather than failing later in gzfile()
+    expect_error(wru_data_preflight(), "wru-data-census_last_c\\.rds")
+    ## carries the underlying download failure through
+    expect_error(wru_data_preflight(), "argument is of length zero")
+    ## and names the release it tried to read from
+    expect_error(wru_data_preflight(), "v4\\.0\\.0")
+  })
+})
+
+test_that("a download that reports success but writes nothing still errors", {
+  with_data_dir("wru-preflight-silent", code = function(dir) {
+    local_mocked_bindings(pb_download = function(...) invisible(NULL), .package = "wru")
+    expect_error(wru_data_preflight(), "wru-data-census_last_c\\.rds")
+  })
+})
+
+test_that("a failed download falls back to data already on disk", {
+  with_data_dir("wru-preflight-cached", files = CORE, code = function(dir) {
+    local_mocked_bindings(
+      pb_download = function(...) stop("HTTP 403 rate limit exceeded"),
+      .package = "wru"
+    )
+    ## Reported, but not fatal: the cached copies are usable offline.
+    expect_message(wru_data_preflight(), "rate limit exceeded")
+  })
+})
+
+test_that("a successful download is silent", {
+  with_data_dir("wru-preflight-ok", code = function(dir) {
+    local_mocked_bindings(
+      pb_download = function(...) {
+        for (f in CORE) saveRDS(data.frame(), file.path(dir, f))
+        invisible(NULL)
+      },
+      .package = "wru"
+    )
+    expect_no_error(wru_data_preflight())
+    expect_no_message(wru_data_preflight())
+  })
+})


### PR DESCRIPTION
Rebaselines the `predict_race()` test fixtures on the 2020 Census surname dictionary, and makes a failed name-dictionary download raise a clear error.
